### PR TITLE
fix(ssp): Refactor ssp client to use qt signal/slot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,15 @@ set(obs-ssp_SOURCES
 		src/controller/cameracontroller.cpp
 		src/ssp-mdns.cpp
 		src/ssp-controller.cpp
-		src/VFrameQueue.cpp )
+		src/VFrameQueue.cpp
+		src/ssp-client.cpp)
 
 set(obs-ssp_HEADERS
-		src/obs-ssp.h src/ssp-mdns.h src/ssp-controller.h src/VFrameQueue.h)
+		src/obs-ssp.h
+		src/ssp-mdns.h
+		src/ssp-controller.h
+		src/VFrameQueue.h
+		src/ssp-client.h)
 
 add_library(obs-ssp MODULE
 	${obs-ssp_SOURCES}

--- a/src/ssp-client.cpp
+++ b/src/ssp-client.cpp
@@ -1,0 +1,128 @@
+/*
+obs-ssp
+ Copyright (C) 2019-2020 Yibai Zhang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; If not, see <https://www.gnu.org/licenses/>
+*/
+
+#include <obs.h>
+
+#include "obs-ssp.h"
+#include "ssp-client.h"
+
+SSPClient::SSPClient(const std::string &ip, uint32_t bufferSize) {
+    this->ip = ip;
+    this->bufferSize = bufferSize;
+    this->threadLoop = nullptr;
+    this->impl = nullptr;
+    this->running = false;
+    connect(this, SIGNAL(Start()), this, SLOT(doStart()));
+    connect(this, SIGNAL(Stop()), this, SLOT(doStop()));
+}
+using namespace std::placeholders;
+
+void SSPClient::doStart() {
+    loopLock.lock();
+    if(this->threadLoop) {
+        loopLock.unlock();
+        return;
+    }
+    this->threadLoop = new imf::ThreadLoop(std::bind(SSPClient::PreStart, this, _1), create_loop_class);
+    this->threadLoop->start();
+    loopLock.unlock();
+}
+
+void SSPClient::doStop() {
+    implLock.lock();
+    if(impl) {
+        impl->stop();
+        impl->destroy();
+        impl = nullptr;
+    }
+    implLock.unlock();
+
+    loopLock.lock();
+    if(threadLoop){
+        threadLoop->stop();
+        delete threadLoop;
+        threadLoop = nullptr;
+    }
+    loopLock.unlock();
+}
+
+void SSPClient::PreStart(SSPClient *my, imf::Loop *loop) {
+    blog(LOG_INFO, "SSPClient starting...");
+    if(!my || ! loop) {
+        return;
+    }
+    my->implLock.lock();
+    my->impl = create_ssp_class(my->ip, loop, my->bufferSize, 9999, imf::STREAM_DEFAULT);
+    my->impl->init();
+    if(my->bufferFullCallback) {
+        my->impl->setOnRecvBufferFullCallback(my->bufferFullCallback);
+    }
+    if(my->exceptionCallback) {
+        my->impl->setOnExceptionCallback(my->exceptionCallback);
+    }
+    if(my->h264DataCallback) {
+        my->impl->setOnH264DataCallback(my->h264DataCallback);
+    }
+    if(my->connectedCallback) {
+        my->impl->setOnConnectionConnectedCallback(my->connectedCallback);
+    }
+    if(my->disconnectedCallback) {
+        my->impl->setOnDisconnectedCallback(my->disconnectedCallback);
+    }
+    if(my->metaCallback) {
+        my->impl->setOnMetaCallback(my->metaCallback);
+    }
+    if(my->audioDataCallback) {
+        my->impl->setOnAudioDataCallback(my->audioDataCallback);
+    }
+    blog(LOG_INFO, "SSPClient 2starting...");
+    my->impl->start();
+    my->implLock.unlock();
+}
+
+void SSPClient::setOnRecvBufferFullCallback(const imf::OnRecvBufferFullCallback &cb) {
+    this->bufferFullCallback = cb;
+}
+
+void SSPClient::setOnAudioDataCallback(const imf::OnAudioDataCallback &cb) {
+    this->audioDataCallback = cb;
+}
+
+void SSPClient::setOnMetaCallback(const imf::OnMetaCallback &cb) {
+    this->metaCallback = cb;
+}
+
+void SSPClient::setOnDisconnectedCallback(const imf::OnDisconnectedCallback &cb) {
+    this->disconnectedCallback = cb;
+}
+
+void SSPClient::setOnConnectionConnectedCallback(const imf::OnConnectionConnectedCallback &cb) {
+    this->connectedCallback = cb;
+}
+
+void SSPClient::setOnH264DataCallback(const imf::OnH264DataCallback &cb) {
+    this->h264DataCallback = cb;
+}
+
+void SSPClient::setOnExceptionCallback(const imf::OnExceptionCallback &cb) {
+    this->exceptionCallback = cb;
+}
+
+SSPClient::~SSPClient() {
+    doStop();
+}

--- a/src/ssp-client.h
+++ b/src/ssp-client.h
@@ -1,0 +1,74 @@
+/*
+obs-ssp
+ Copyright (C) 2019-2020 Yibai Zhang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; If not, see <https://www.gnu.org/licenses/>
+*/
+
+#ifndef OBS_SSP_SSP_CLIENT_H
+#define OBS_SSP_SSP_CLIENT_H
+#include <QObject>
+#include <mutex>
+
+#include <imf/ISspClient.h>
+#include <imf/threadloop.h>
+
+class SSPClient : public QObject{
+    Q_OBJECT
+
+public:
+    SSPClient(const std::string &ip, uint32_t bufferSize);
+    ~SSPClient();
+    static void PreStart(SSPClient *my, imf::Loop *loop);
+
+    virtual void setOnRecvBufferFullCallback(const imf::OnRecvBufferFullCallback & cb);
+    virtual void setOnH264DataCallback(const imf::OnH264DataCallback & cb);
+    virtual void setOnAudioDataCallback(const imf::OnAudioDataCallback & cb);
+    virtual void setOnMetaCallback(const imf::OnMetaCallback & cb);
+    virtual void setOnDisconnectedCallback(const imf::OnDisconnectedCallback & cb);
+    virtual void setOnConnectionConnectedCallback(const imf::OnConnectionConnectedCallback & cb);
+    virtual void setOnExceptionCallback(const imf::OnExceptionCallback & cb);
+
+signals:
+    void Start();
+    void Stop();
+
+private slots:
+    void doStart();
+    void doStop();
+
+private:
+    imf::ThreadLoop *threadLoop;
+    imf::ISspClient_class *impl;
+    std::mutex implLock;
+    std::mutex loopLock;
+    bool running;
+    std::string ip;
+    uint32_t bufferSize;
+
+    imf::OnRecvBufferFullCallback bufferFullCallback;
+    imf::OnH264DataCallback h264DataCallback;
+    imf::OnAudioDataCallback audioDataCallback;
+    imf::OnConnectionConnectedCallback connectedCallback;
+    imf::OnDisconnectedCallback disconnectedCallback;
+    imf::OnMetaCallback metaCallback;
+    imf::OnExceptionCallback exceptionCallback;
+};
+
+/*
+  s->clientLooper = new imf::ThreadLoop(std::bind(ssp_setup_client, _1, s), create_loop_class);
+ */
+
+
+#endif //OBS_SSP_SSP_CLIENT_H

--- a/src/ssp-mdns.cpp
+++ b/src/ssp-mdns.cpp
@@ -373,7 +373,7 @@ send_mdns_query(const char* service, size_t service_len) {
 		query_id[isock] = mdns_query_send(sockets[isock], MDNS_RECORDTYPE_PTR, service,
 		                                  service_len, buffer, capacity, current_id++);
 		if (query_id[isock] < 0)
-			blog(LOG_INFO, "Failed to send mDNS query: %s", strerror(errno));
+			blog(LOG_DEBUG, "Failed to send mDNS query: %s", strerror(errno));
 	}
 
 	// This is a simple implementation that loops for 5 seconds or as long as we get replies


### PR DESCRIPTION
In that case, we can delegate uv loop start and stop to main thread
and fix the unintended crash on macOS.

Signed-off-by: Yibai Zhang <xm1994@gmail.com>