### PR TITLE
fix(sspclient): Free SSPClient on the main thread.

### DIFF
--- a/src/obs-ssp-source.cpp
+++ b/src/obs-ssp-source.cpp
@@ -274,8 +274,7 @@ static void ssp_conn_stop(ssp_connection *conn) {
     auto queue = conn->queue;
 
     if(client){
-        emit client->Stop();
-        delete client;
+        emit client->Destroy();
     }
     if(queue){
         queue->stop();
@@ -294,7 +293,7 @@ static void ssp_conn_stop(ssp_connection *conn) {
     blog(LOG_INFO, "SSP released.");
 }
 
-static void* thread_ssp_conn_stop(void *data) {
+static void* thread_ssp_stop(void *data) {
     auto *conn = (ssp_connection *)data;
     if(!data) {
         return nullptr;
@@ -309,7 +308,7 @@ static void ssp_stop(ssp_source *s, bool detach = false){
         return ;
     }
     pthread_t thread;
-    pthread_create(&thread, nullptr, thread_ssp_conn_stop, (void *)s->conn);
+    pthread_create(&thread, nullptr, thread_ssp_stop, (void *) s->conn);
     s->conn = nullptr;
     if(detach) {
         pthread_detach(thread);

--- a/src/ssp-client.cpp
+++ b/src/ssp-client.cpp
@@ -28,7 +28,7 @@ SSPClient::SSPClient(const std::string &ip, uint32_t bufferSize) {
     this->impl = nullptr;
     this->running = false;
     connect(this, SIGNAL(Start()), this, SLOT(doStart()));
-    connect(this, SIGNAL(Stop()), this, SLOT(doStop()));
+    connect(this, SIGNAL(Destroy()), this, SLOT(doDestroy()));
 }
 using namespace std::placeholders;
 
@@ -43,7 +43,7 @@ void SSPClient::doStart() {
     loopLock.unlock();
 }
 
-void SSPClient::doStop() {
+void SSPClient::doDestroy() {
     implLock.lock();
     if(impl) {
         impl->stop();
@@ -59,10 +59,10 @@ void SSPClient::doStop() {
         threadLoop = nullptr;
     }
     loopLock.unlock();
+    delete this;
 }
 
 void SSPClient::PreStart(SSPClient *my, imf::Loop *loop) {
-    blog(LOG_INFO, "SSPClient starting...");
     if(!my || ! loop) {
         return;
     }
@@ -90,7 +90,6 @@ void SSPClient::PreStart(SSPClient *my, imf::Loop *loop) {
     if(my->audioDataCallback) {
         my->impl->setOnAudioDataCallback(my->audioDataCallback);
     }
-    blog(LOG_INFO, "SSPClient 2starting...");
     my->impl->start();
     my->implLock.unlock();
 }
@@ -121,8 +120,4 @@ void SSPClient::setOnH264DataCallback(const imf::OnH264DataCallback &cb) {
 
 void SSPClient::setOnExceptionCallback(const imf::OnExceptionCallback &cb) {
     this->exceptionCallback = cb;
-}
-
-SSPClient::~SSPClient() {
-    doStop();
 }

--- a/src/ssp-client.h
+++ b/src/ssp-client.h
@@ -29,7 +29,6 @@ class SSPClient : public QObject{
 
 public:
     SSPClient(const std::string &ip, uint32_t bufferSize);
-    ~SSPClient();
     static void PreStart(SSPClient *my, imf::Loop *loop);
 
     virtual void setOnRecvBufferFullCallback(const imf::OnRecvBufferFullCallback & cb);
@@ -42,11 +41,12 @@ public:
 
 signals:
     void Start();
-    void Stop();
+    /* Never Use an instance after destroy!!!!!! */
+    void Destroy();
 
 private slots:
     void doStart();
-    void doStop();
+    void doDestroy();
 
 private:
     imf::ThreadLoop *threadLoop;


### PR DESCRIPTION
A little tricky to use 'delete this'. So NEVER use a SSPClient
instance after destroy it.

Signed-off-by: Yibai Zhang <xm1994@gmail.com>