### PR TITLE
fix(plugin): Change libssp search method on win.

### DIFF
--- a/src/obs-ssp.cpp
+++ b/src/obs-ssp.cpp
@@ -24,6 +24,7 @@ along with this program; If not, see <https://www.gnu.org/licenses/>
 
 #include <obs-module.h>
 #include <util/platform.h>
+#include <util/dstr.h>
 
 #include "obs-ssp.h"
 #include "ssp-controller.h"
@@ -40,8 +41,9 @@ create_loop_class_ptr create_loop_class;
 
 bool obs_module_load(void)
 {
-	ssp_blog(LOG_INFO, "hello ! (obs-ssp version %s) size: %lu", OBS_SSP_VERSION, sizeof(ssp_source_info));
+    ssp_blog(LOG_INFO, "hello ! (obs-ssp version %s) size: %lu", OBS_SSP_VERSION, sizeof(ssp_source_info));
     void *ssp_handle = os_dlopen(LIBSSP_LIBRARY_NAME);
+
     if(!ssp_handle){
         ssp_blog(LOG_WARNING, "Load %s failed.", LIBSSP_LIBRARY_NAME);
         return false;
@@ -61,23 +63,23 @@ bool obs_module_load(void)
     ssp_blog(LOG_INFO, "libssp load successful!");
 
     create_mdns_loop();
-	ssp_source_info = create_ssp_source_info();
-	obs_register_source(&ssp_source_info);
-	return true;
+    ssp_source_info = create_ssp_source_info();
+    obs_register_source(&ssp_source_info);
+    return true;
 }
 
 void obs_module_unload()
 {
     stop_mdns_loop();
-	ssp_blog(LOG_INFO, "goodbye !");
+    ssp_blog(LOG_INFO, "goodbye !");
 }
 
 const char* obs_module_name()
 {
-	return "obs-ssp";
+    return "obs-ssp";
 }
 
 const char* obs_module_description()
 {
-	return "Simple Stream Protocol input integration for OBS Studio";
+    return "Simple Stream Protocol input integration for OBS Studio";
 }

--- a/src/obs-ssp.h
+++ b/src/obs-ssp.h
@@ -21,6 +21,16 @@ along with this program; If not, see <https://www.gnu.org/licenses/>
 
 #include <string>
 #include "imf/ISspClient.h"
+#include <stdint.h>
+
+#if INTPTR_MAX == INT64_MAX
+#   define OBS_SSP_BITSTR "64bit"
+#elif INTPTR_MAX == INT32_MAX
+#   define OBS_SSP_BITSTR "32bit"
+#else
+#error Unknown pointer size or missing size macros!
+#endif
+
 
 #ifndef OBS_SSP_VERSION
 #define OBS_SSP_VERSION "unknown"
@@ -32,7 +42,7 @@ extern create_ssp_class_ptr create_ssp_class;
 extern create_loop_class_ptr create_loop_class;
 
 #ifdef _WIN64
-#   define LIBSSP_LIBRARY_NAME "libssp.dll"
+#   define LIBSSP_LIBRARY_NAME "../../obs-plugins/"OBS_SSP_BITSTR"/libssp.dll"
 #elif defined(__APPLE__)
 #   define LIBSSP_LIBRARY_NAME "/Library/Application Support/obs-studio/plugins/obs-ssp/bin/libssp.dylib"
 #else


### PR DESCRIPTION
It seems that obs-studio 27.2.x changes the default library search
path, the old way we use is not working on newer version.
We change it to the relative path than obs.exe and fix #60 

Signed-off-by: Yibai Zhang <xm1994@gmail.com>