### PR TITLE
fix(decoder): Optimize hw decode code.

### DIFF
--- a/src/ffmpeg-decode.h
+++ b/src/ffmpeg-decode.h
@@ -43,6 +43,7 @@ struct ffmpeg_decode {
 	AVFrame *hw_frame;
 	AVFrame *frame;
 	bool hw;
+	enum AVPixelFormat hw_pix_fmt;
 
 	uint8_t *packet_buffer;
 	size_t packet_size;


### PR DESCRIPTION
Since the old way may crash on some situation, we copy some code
from ffmpeg/example/hw-decode.c. Now it's working.

Signed-off-by: Yibai Zhang <xm1994@gmail.com>