### PR TITLE
ssp: isolate libssp to standalone process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,8 @@ set(obs-ssp_SOURCES
     src/ssp-mdns.cpp
     src/ssp-controller.cpp
     src/VFrameQueue.cpp
-    src/ssp-client.cpp)
+    src/ssp-client.cpp
+    src/ssp-client-iso.cpp)
 
 set(obs-ssp_HEADERS src/obs-ssp.h src/ssp-mdns.h src/ssp-controller.h src/VFrameQueue.h
                     src/ssp-client.h)
@@ -67,8 +68,9 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-macros.generated.h)
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil)
 add_subdirectory(thirdpty)
 
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src
-                                                         ${CMAKE_SOURCE_DIR}/lib/ssp/include)
+target_include_directories(
+  ${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/lib/ssp/include
+                                ${CMAKE_SOURCE_DIR}/ssp_connector)
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::libobs FFmpeg::avcodec FFmpeg::avutil mdns)
 
@@ -111,24 +113,12 @@ endif()
 
 setup_plugin_target(${CMAKE_PROJECT_NAME})
 
-if(OS_WINDOWS)
-  set(LIBSSP_DOWNLOAD_ADDR
-      "https://github.com/imaginevision/libssp/raw/fa0affd3858049a7773995c38bb454f989e7c8f4/lib/win_x64_vs2017/libssp.dll"
-  )
-  set(LIBSSP_FILENAME "libssp.dll")
-  set(LIBSSP_HASH "SHA256=905cdccf06d8eededa18c26b21395404e64a086cc3e87679d4bd8cd38c7497d3")
-  set(LIBSSP_INSTALL_PREFIX "${OBS_PLUGIN_DESTINATION}")
-elseif(OS_MACOS)
-  set(LIBSSP_DOWNLOAD_ADDR
-      "https://github.com/summershrimp/obs-deps/releases/download/2021-04-03/libssp.dylib")
-  set(LIBSSP_FILENAME "libssp.dylib")
-  set(LIBSSP_HASH "SHA256=5e04060a8f248785202b0b097cc52a0c23c2f8cff8796c9d3c0672da28d9cf0c")
-  set(LIBSSP_INSTALL_PREFIX "./${CMAKE_PROJECT_NAME}.plugin/Contents/Frameworks")
-endif()
+add_subdirectory(ssp_connector)
 
-if(LIBSSP_DOWNLOAD_ADDR)
-  install(
-    CODE "file(DOWNLOAD \"${LIBSSP_DOWNLOAD_ADDR}\" \"${CMAKE_BINARY_DIR}/${LIBSSP_FILENAME}\" SHOW_PROGRESS EXPECTED_HASH \"${LIBSSP_HASH}\")
-          file(INSTALL \"${CMAKE_BINARY_DIR}/${LIBSSP_FILENAME}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${LIBSSP_INSTALL_PREFIX}\")"
-  )
+if(OS_MACOS)
+  install(TARGETS ssp-connector DESTINATION "./${CMAKE_PROJECT_NAME}.plugin/Contents/MacOS")
+  install(FILES ${LIBSSP_LIBRARY} DESTINATION "./${CMAKE_PROJECT_NAME}.plugin/Contents/Frameworks")
+elseif(OS_WINDOWS)
+  install(TARGETS ssp-connector DESTINATION "${OBS_LIBRARY_DESTINATION}")
+  install(FILES ${LIBSSP_LIBRARY} DESTINATION "${OBS_LIBRARY_DESTINATION}")
 endif()

--- a/lib/ssp/include/imf/ISspClient.h
+++ b/lib/ssp/include/imf/ISspClient.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 #include <stdint.h>
 #include <functional>
 

--- a/lib/ssp/include/imf/sspclient.h
+++ b/lib/ssp/include/imf/sspclient.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "ISspClient.h"
+namespace imf {
+extern "C" {
+ISspClient_class *create_ssp_class(const std::string &ip, Loop *loop,
+				   size_t bufSize, unsigned short port,
+				   uint32_t streamStyle);
+ILoop_class *create_loop_class();
+}
+}

--- a/lib/ssp/include/imf/threadloop.h
+++ b/lib/ssp/include/imf/threadloop.h
@@ -49,7 +49,6 @@ public:
 		thread_.join();
 	}
 
-private:
 	void run(void)
 	{
 		if (loop_) {
@@ -64,6 +63,7 @@ private:
 		loop_->loop();
 	}
 
+private:
 	PreLoopCallback preLoopCb_;
 	bool started_;
 	std::thread thread_;

--- a/src/obs-ssp-source.cpp
+++ b/src/obs-ssp-source.cpp
@@ -40,7 +40,7 @@ along with this program; If not, see <https://www.gnu.org/licenses/>
 #include "imf/threadloop.h"
 
 #include "ssp-controller.h"
-#include "ssp-client.h"
+#include "ssp-client-iso.h"
 #include "VFrameQueue.h"
 
 extern "C" {
@@ -87,7 +87,7 @@ using namespace std::placeholders;
 struct ssp_source;
 
 struct ssp_connection {
-	SSPClient *client;
+	SSPClientIso *client;
 	ffmpeg_decode vdecoder;
 	uint32_t width;
 	uint32_t height;
@@ -350,7 +350,7 @@ static void ssp_conn_start(ssp_connection *s)
 		return;
 	}
 	pthread_mutex_lock(&s->lck);
-	s->client = new SSPClient(ip, s->source->bitrate / 8);
+	s->client = new SSPClientIso(ip, s->source->bitrate / 8);
 	s->client->setOnH264DataCallback(
 		std::bind(ssp_video_data_enqueue, _1, s));
 	s->client->setOnAudioDataCallback(std::bind(ssp_on_audio_data, _1, s));
@@ -416,7 +416,7 @@ void *thread_ssp_reconnect(void *data)
 		pthread_mutex_unlock(&conn->lck);
 		return nullptr;
 	}
-	conn->client = new SSPClient(ip, conn->source->bitrate / 8);
+	conn->client = new SSPClientIso(ip, conn->source->bitrate / 8);
 	conn->client->setOnH264DataCallback(
 		std::bind(ssp_video_data_enqueue, _1, conn));
 	conn->client->setOnAudioDataCallback(

--- a/src/obs-ssp.cpp
+++ b/src/obs-ssp.cpp
@@ -48,41 +48,6 @@ bool obs_module_load(void)
 {
 	ssp_blog(LOG_INFO, "hello ! (obs-ssp version %s) size: %lu",
 		 PLUGIN_VERSION, sizeof(ssp_source_info));
-#if defined(__APPLE__)
-	Dl_info info;
-	dladdr((const void *)obs_module_load, &info);
-	blog(LOG_INFO, "path: %s", info.dli_fname);
-	QFileInfo plugin_path(info.dli_fname);
-
-	void *ssp_handle =
-		os_dlopen(plugin_path.dir()
-				  .filePath(QStringLiteral(LIBSSP_LIBRARY_NAME))
-				  .toStdString()
-				  .c_str());
-#else
-	void *ssp_handle = os_dlopen(LIBSSP_LIBRARY_NAME);
-#endif
-	if (!ssp_handle) {
-		ssp_blog(LOG_WARNING, "Load %s failed.", LIBSSP_LIBRARY_NAME);
-		return false;
-	}
-	create_ssp_class =
-		(create_ssp_class_ptr)os_dlsym(ssp_handle, "create_ssp_class");
-	if (!create_ssp_class) {
-		ssp_blog(LOG_WARNING, "Cannot find create_ssp_class() in %s.",
-			 LIBSSP_LIBRARY_NAME);
-		return false;
-	}
-
-	create_loop_class = (create_loop_class_ptr)os_dlsym(
-		ssp_handle, "create_loop_class");
-	if (!create_loop_class) {
-		ssp_blog(LOG_WARNING, "Cannot find create_loop_class() in %s.",
-			 LIBSSP_LIBRARY_NAME);
-		return false;
-	}
-
-	ssp_blog(LOG_INFO, "libssp load successful!");
 
 	create_mdns_loop();
 	ssp_source_info = create_ssp_source_info();

--- a/src/ssp-client-iso.cpp
+++ b/src/ssp-client-iso.cpp
@@ -1,0 +1,295 @@
+/*
+obs-ssp
+ Copyright (C) 2019-2020 Yibai Zhang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; If not, see <https://www.gnu.org/licenses/>
+*/
+
+#include <obs.h>
+#include <util/dstr.h>
+#include <util/platform.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#if defined(__APPLE__)
+#include <dlfcn.h>
+#endif
+
+#include <QUuid>
+#include <QFileInfo>
+#include <QDir>
+#include <pthread.h>
+
+#include "obs-ssp.h"
+#include "ssp-client-iso.h"
+
+static Message *msg_recv(os_process_pipe *pipe)
+{
+	size_t sz = 0;
+	Message *msg = (Message *)bmalloc(sizeof(Message));
+	if (!msg) {
+		return nullptr;
+	}
+	sz = os_process_pipe_read(pipe, (uint8_t *)msg, sizeof(Message));
+	if (sz != sizeof(Message)) {
+		bfree(msg);
+		return nullptr;
+	}
+	if (msg->length == 0) {
+		return msg;
+	}
+	Message *msg_all = nullptr;
+	msg_all = (Message *)bmalloc(sizeof(Message) + msg->length);
+	memcpy(msg_all, msg, sizeof(Message));
+	bfree(msg);
+	sz = os_process_pipe_read(pipe, msg_all->value, msg_all->length);
+	if (sz != msg_all->length) {
+		bfree(msg_all);
+		return nullptr;
+	}
+	return msg_all;
+}
+
+static void msg_free(Message *msg)
+{
+	if (msg) {
+		bfree(msg);
+	}
+}
+
+SSPClientIso::SSPClientIso(const std::string &ip, uint32_t bufferSize)
+{
+	this->ip = ip;
+	this->bufferSize = bufferSize;
+	this->running = false;
+
+#if defined(__APPLE__)
+	Dl_info info;
+	dladdr((const void *)msg_free, &info);
+	QFileInfo plugin_path(info.dli_fname);
+	ssp_connector_path =
+		plugin_path.dir().filePath(QStringLiteral(SSP_CONNECTOR));
+#else
+	ssp_connector_path = QStringLiteral(SSP_CONNECTOR);
+#endif
+	connect(this, SIGNAL(Start()), this, SLOT(doStart()));
+}
+using namespace std::placeholders;
+
+void SSPClientIso::doStart()
+{
+	struct dstr cmd;
+
+	dstr_init_copy(&cmd, ssp_connector_path.toStdString().c_str());
+	dstr_insert_ch(&cmd, 0, '\"');
+	dstr_cat(&cmd, "\" ");
+#if defined(__APPLE__) && defined(__arm64__)
+	dstr_insert(&cmd, 0, "arch -x86_64 ");
+#endif
+	dstr_cat(&cmd, "--host ");
+	dstr_cat(&cmd, this->ip.c_str());
+	dstr_cat(&cmd, " --port ");
+	dstr_cat(&cmd, "9999");
+
+	this->pipe = os_process_pipe_create(cmd.array, "r");
+	blog(LOG_INFO, "Start ssp-connector at: %s", cmd.array);
+	dstr_free(&cmd);
+
+	if (!this->pipe) {
+		blog(LOG_WARNING, "Start ssp-connector failed.");
+		return;
+	}
+	this->running = true;
+
+	pthread_t thread;
+	pthread_create(&thread, nullptr, SSPClientIso::ReceiveThread, this);
+	pthread_detach(thread);
+}
+
+void *SSPClientIso::ReceiveThread(void *arg)
+{
+	auto th = (SSPClientIso *)arg;
+	Message *msg;
+
+	msg = msg_recv(th->pipe);
+	if (!msg) {
+		blog(LOG_WARNING, "Receive error !");
+		th->running = false;
+		return nullptr;
+	}
+	if (msg->type != MessageType::ConnectorOkMsg) {
+		blog(LOG_WARNING, "Protocol error !");
+		th->Stop();
+		return nullptr;
+	}
+
+	while (th->running) {
+		msg = msg_recv(th->pipe);
+		if (!msg) {
+			blog(LOG_WARNING, "Receive error !");
+			th->Stop();
+			break;
+		}
+
+		switch (msg->type) {
+		case MessageType::MetaDataMsg:
+			th->OnMetadata((Metadata *)msg->value);
+			break;
+		case MessageType::VideoDataMsg:
+			th->OnH264Data((VideoData *)msg->value);
+			break;
+		case MessageType::AudioDataMsg:
+			th->OnAudioData((AudioData *)msg->value);
+			break;
+		case MessageType::RecvBufferFullMsg:
+			th->OnRecvBufferFull();
+			break;
+		case MessageType::DisconnectMsg:
+			th->OnDisconnected();
+			break;
+		case MessageType::ConnectionConnectedMsg:
+			th->OnConnectionConnected();
+			break;
+		case MessageType::ExceptionMsg:
+			th->OnException((Message *)msg->value);
+			break;
+		default:
+			blog(LOG_WARNING, "Protocol error !");
+			th->Stop();
+			break;
+		}
+
+		msg_free(msg);
+	}
+	return nullptr;
+}
+
+void SSPClientIso::Restart()
+{
+	this->Stop();
+	emit this->Start();
+}
+
+void SSPClientIso::Stop()
+{
+	blog(LOG_INFO, "ssp client stopping...");
+	this->running = false;
+	os_process_pipe_destroy(this->pipe);
+}
+
+void SSPClientIso::OnRecvBufferFull()
+{
+	this->bufferFullCallback();
+}
+
+void SSPClientIso::OnH264Data(VideoData *videoData)
+{
+	imf::SspH264Data video;
+	video.frm_no = videoData->frm_no;
+	video.ntp_timestamp = videoData->ntp_timestamp;
+	video.pts = videoData->pts;
+	video.type = videoData->type;
+	video.len = videoData->len;
+	video.data = videoData->data;
+	this->h264DataCallback(&video);
+}
+void SSPClientIso::OnAudioData(AudioData *audioData)
+{
+	struct imf::SspAudioData audio;
+	audio.ntp_timestamp = audioData->ntp_timestamp;
+	audio.pts = audioData->pts;
+	audio.len = audioData->len;
+	audio.data = audioData->data;
+	this->audioDataCallback(&audio);
+}
+void SSPClientIso::OnMetadata(Metadata *metadata)
+{
+
+	struct imf::SspVideoMeta vmeta;
+	struct imf::SspAudioMeta ameta;
+	struct imf::SspMeta meta;
+
+	ameta.bitrate = metadata->ameta.bitrate;
+	ameta.channel = metadata->ameta.channel;
+	ameta.encoder = metadata->ameta.encoder;
+	ameta.sample_rate = metadata->ameta.sample_rate;
+	ameta.sample_size = metadata->ameta.sample_size;
+	ameta.timescale = metadata->ameta.timescale;
+	ameta.unit = metadata->ameta.unit;
+
+	vmeta.encoder = metadata->vmeta.encoder;
+	vmeta.gop = metadata->vmeta.gop;
+	vmeta.height = metadata->vmeta.height;
+	vmeta.timescale = metadata->vmeta.timescale;
+	vmeta.unit = metadata->vmeta.unit;
+	vmeta.width = metadata->vmeta.width;
+
+	meta.pts_is_wall_clock = metadata->meta.pts_is_wall_clock;
+	meta.tc_drop_frame = metadata->meta.tc_drop_frame;
+	meta.timecode = metadata->meta.timecode;
+
+	this->metaCallback(&vmeta, &ameta, &meta);
+}
+void SSPClientIso::OnDisconnected()
+{
+	this->disconnectedCallback();
+}
+void SSPClientIso::OnConnectionConnected()
+{
+	this->connectedCallback();
+}
+void SSPClientIso::OnException(Message *exception)
+{
+	this->exceptionCallback(exception->type, (char *)exception->value);
+}
+
+void SSPClientIso::setOnRecvBufferFullCallback(
+	const imf::OnRecvBufferFullCallback &cb)
+{
+	this->bufferFullCallback = cb;
+}
+
+void SSPClientIso::setOnAudioDataCallback(const imf::OnAudioDataCallback &cb)
+{
+	this->audioDataCallback = cb;
+}
+
+void SSPClientIso::setOnMetaCallback(const imf::OnMetaCallback &cb)
+{
+	this->metaCallback = cb;
+}
+
+void SSPClientIso::setOnDisconnectedCallback(
+	const imf::OnDisconnectedCallback &cb)
+{
+	this->disconnectedCallback = cb;
+}
+
+void SSPClientIso::setOnConnectionConnectedCallback(
+	const imf::OnConnectionConnectedCallback &cb)
+{
+	this->connectedCallback = cb;
+}
+
+void SSPClientIso::setOnH264DataCallback(const imf::OnH264DataCallback &cb)
+{
+	this->h264DataCallback = cb;
+}
+
+void SSPClientIso::setOnExceptionCallback(const imf::OnExceptionCallback &cb)
+{
+	this->exceptionCallback = cb;
+}

--- a/src/ssp-client-iso.h
+++ b/src/ssp-client-iso.h
@@ -1,0 +1,89 @@
+/*
+obs-ssp
+ Copyright (C) 2019-2020 Yibai Zhang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; If not, see <https://www.gnu.org/licenses/>
+*/
+
+#ifndef OBS_SSP_SSP_CLIENT_ISO_H
+#define OBS_SSP_SSP_CLIENT_ISO_H
+#include <QObject>
+#include <QProcess>
+#include <mutex>
+
+#include <imf/ISspClient.h>
+extern "C" {
+#include <util/pipe.h>
+}
+#include <ssp_connector_proto.h>
+
+#ifdef _WIN64
+#define SSP_CONNECTOR "../../obs-plugins/" OBS_SSP_BITSTR "/ssp-connector.exe"
+#else
+#define SSP_CONNECTOR "ssp-connector"
+#endif
+
+class SSPClientIso : public QObject {
+	Q_OBJECT
+
+public:
+	SSPClientIso(const std::string &ip, uint32_t bufferSize);
+
+	virtual void
+	setOnRecvBufferFullCallback(const imf::OnRecvBufferFullCallback &cb);
+	virtual void setOnH264DataCallback(const imf::OnH264DataCallback &cb);
+	virtual void setOnAudioDataCallback(const imf::OnAudioDataCallback &cb);
+	virtual void setOnMetaCallback(const imf::OnMetaCallback &cb);
+	virtual void
+	setOnDisconnectedCallback(const imf::OnDisconnectedCallback &cb);
+	virtual void setOnConnectionConnectedCallback(
+		const imf::OnConnectionConnectedCallback &cb);
+	virtual void setOnExceptionCallback(const imf::OnExceptionCallback &cb);
+	void Stop();
+	void Restart();
+	static void *ReceiveThread(void *arg);
+signals:
+	void Start();
+
+private slots:
+	void doStart();
+
+private:
+	virtual void OnRecvBufferFull();
+	virtual void OnH264Data(VideoData *video);
+	virtual void OnAudioData(AudioData *audio);
+	virtual void OnMetadata(Metadata *meta);
+	virtual void OnDisconnected();
+	virtual void OnConnectionConnected();
+	virtual void OnException(Message *exception);
+
+	std::mutex implLock;
+	std::mutex loopLock;
+	bool running;
+	std::string ip;
+	uint32_t bufferSize;
+	QString ssp_connector_path;
+
+	os_process_pipe_t *pipe;
+
+	imf::OnRecvBufferFullCallback bufferFullCallback;
+	imf::OnH264DataCallback h264DataCallback;
+	imf::OnAudioDataCallback audioDataCallback;
+	imf::OnConnectionConnectedCallback connectedCallback;
+	imf::OnDisconnectedCallback disconnectedCallback;
+	imf::OnMetaCallback metaCallback;
+	imf::OnExceptionCallback exceptionCallback;
+};
+
+#endif //OBS_SSP_SSP_CLIENT_ISO_H

--- a/ssp_connector/CMakeLists.txt
+++ b/ssp_connector/CMakeLists.txt
@@ -1,0 +1,36 @@
+project(ssp-connector)
+
+include(FetchContent)
+FetchContent_Declare(
+  libssp
+  GIT_REPOSITORY "https://github.com/imaginevision/libssp.git"
+  GIT_TAG ee754be1d2ed54633ff467a7cd6fec14c9b0b537)
+
+if(NOT libssp_POPULATED)
+  FetchContent_Populate(libssp)
+  add_library(libssp INTERFACE)
+  target_include_directories(libssp INTERFACE ${libssp_SOURCE_DIR}/include)
+  if(OS_WINDOWS)
+    target_link_libraries(
+      libssp INTERFACE "${libssp_SOURCE_DIR}/lib/win_x64_vs2017/libssp$<$<CONFIG:Debug>:d>.lib")
+    set(LIBSSP_LIBRARY
+        "${libssp_SOURCE_DIR}/lib/win_x64_vs2017/libssp$<$<CONFIG:Debug>:d>.lib"
+        PARENT_SCOPE)
+  elseif(OS_MACOS)
+    target_link_libraries(libssp INTERFACE ${libssp_SOURCE_DIR}/lib/mac/libssp.dylib)
+    set(LIBSSP_LIBRARY
+        "${libssp_SOURCE_DIR}/lib/mac/libssp.dylib"
+        PARENT_SCOPE)
+  endif()
+endif()
+
+set(SSP_CONNECTOR_SOURCE main.cpp)
+
+add_executable(ssp-connector ${SSP_CONNECTOR_SOURCE})
+set_target_properties(ssp-connector PROPERTIES OSX_ARCHITECTURES x86_64)
+target_link_libraries(ssp-connector PRIVATE libssp)
+target_include_directories(ssp-connector PRIVATE libuv/include)
+
+if(OS_WINDOWS)
+  target_compile_definitions(ssp-connector PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()

--- a/ssp_connector/LICENSE
+++ b/ssp_connector/LICENSE
@@ -1,0 +1,27 @@
+/* 
+ * Copyright (c) 2015-2021, Yibai Zhang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 3.  Neither the name of Yibai Zhang, obs-ssp, ssp_connector
+ *     nor the names contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/ssp_connector/libuv/include/pthread-barrier.h
+++ b/ssp_connector/libuv/include/pthread-barrier.h
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2016, Kari Tristan Helgason <kthelgason@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef _UV_PTHREAD_BARRIER_
+#define _UV_PTHREAD_BARRIER_
+#include <errno.h>
+#include <pthread.h>
+#include <semaphore.h> /* sem_t */
+
+#define PTHREAD_BARRIER_SERIAL_THREAD 0x12345
+
+/*
+ * To maintain ABI compatibility with
+ * libuv v1.x struct is padded according
+ * to target platform
+ */
+#if defined(__ANDROID__)
+#define UV_BARRIER_STRUCT_PADDING                          \
+	sizeof(pthread_mutex_t) + sizeof(pthread_cond_t) + \
+		sizeof(unsigned int) - sizeof(void *)
+#elif defined(__APPLE__)
+#define UV_BARRIER_STRUCT_PADDING                     \
+	sizeof(pthread_mutex_t) + 2 * sizeof(sem_t) + \
+		2 * sizeof(unsigned int) - sizeof(void *)
+#endif
+
+typedef struct {
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+	unsigned threshold;
+	unsigned in;
+	unsigned out;
+} _uv_barrier;
+
+typedef struct {
+	_uv_barrier *b;
+	char _pad[UV_BARRIER_STRUCT_PADDING];
+} pthread_barrier_t;
+
+int pthread_barrier_init(pthread_barrier_t *barrier, const void *barrier_attr,
+			 unsigned count);
+
+int pthread_barrier_wait(pthread_barrier_t *barrier);
+int pthread_barrier_destroy(pthread_barrier_t *barrier);
+
+#endif /* _UV_PTHREAD_BARRIER_ */

--- a/ssp_connector/libuv/include/uv-darwin.h
+++ b/ssp_connector/libuv/include/uv-darwin.h
@@ -1,0 +1,60 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef UV_DARWIN_H
+#define UV_DARWIN_H
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <mach/mach.h>
+#include <mach/task.h>
+#include <mach/semaphore.h>
+#include <TargetConditionals.h>
+#define UV_PLATFORM_SEM_T semaphore_t
+#endif
+
+#define UV_IO_PRIVATE_PLATFORM_FIELDS \
+	int rcount;                   \
+	int wcount;
+
+#define UV_PLATFORM_LOOP_FIELDS \
+	uv_thread_t cf_thread;  \
+	void *_cf_reserved;     \
+	void *cf_state;         \
+	uv_mutex_t cf_mutex;    \
+	uv_sem_t cf_sem;        \
+	void *cf_signals[2];
+
+#define UV_PLATFORM_FS_EVENT_FIELDS \
+	uv__io_t event_watcher;     \
+	char *realpath;             \
+	int realpath_len;           \
+	int cf_flags;               \
+	uv_async_t *cf_cb;          \
+	void *cf_events[2];         \
+	void *cf_member[2];         \
+	int cf_error;               \
+	uv_mutex_t cf_mutex;
+
+#define UV_STREAM_PRIVATE_PLATFORM_FIELDS void *select;
+
+#define UV_HAVE_KQUEUE 1
+
+#endif /* UV_DARWIN_H */

--- a/ssp_connector/main.cpp
+++ b/ssp_connector/main.cpp
@@ -1,0 +1,250 @@
+/* 
+ * Copyright (c) 2015-2021, Yibai Zhang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 3.  Neither the name of Yibai Zhang, obs-ssp, ssp_connector
+ *     nor the names contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <string>
+
+#include <imf/ssp/sspclient.h>
+#include <imf/net/threadloop.h>
+
+#include "main.h"
+#include "ssp_connector_proto.h"
+
+char address[256] = {0};
+unsigned int port = 0;
+char uuid[64] = {0};
+
+uintptr_t pipefd = 0;
+
+imf::SspClient *gSspClient = nullptr;
+imf::Loop *gLoop = nullptr;
+
+int msg_write(char *buf, size_t size)
+{
+	return fwrite(buf, 1, size, stdout);
+}
+
+int process_args(int argc, char **argv)
+{
+	int t = 1;
+	while (t < argc) {
+		if (t + 1 >= argc) {
+			return -1;
+		}
+		if ((!strcmp(argv[t], "-h") || !strcmp(argv[t], "--host"))) {
+			++t;
+			strncpy(address, argv[t], sizeof(address));
+		} else if (!strcmp(argv[t], "-p") ||
+			   !strcmp(argv[t], "--port")) {
+			++t;
+			port = strtoul(argv[t], NULL, 0);
+		} else if (!strcmp(argv[t], "-u") ||
+			   !strcmp(argv[t], "--uuid")) {
+			++t;
+			strncpy(uuid, argv[t], sizeof(uuid));
+		} else {
+			return -1;
+		}
+
+		++t;
+	}
+
+	if (strlen(address) == 0 || port == 0) {
+		return -1;
+	}
+	return 0;
+}
+
+void print_usage(void)
+{
+	puts("Usage: ssp_connector --host host --port port --uuid uuid");
+}
+
+static void on_general_message(MessageType type)
+{
+	Message msg;
+	msg.length = 0;
+	msg.type = type;
+	int sz = msg_write((char *)&msg, sizeof(msg));
+	if (sz != sizeof(msg)) {
+		log_conn("stopped.");
+		gSspClient->stop();
+		gLoop->quit();
+	}
+}
+
+static void on_video(imf::SspH264Data *video)
+{
+	size_t len = sizeof(Message) + sizeof(VideoData) + video->len;
+	auto *msg = (Message *)malloc(len);
+	msg->type = VideoDataMsg;
+	msg->length = sizeof(VideoData) + video->len;
+	auto *videoData = (VideoData *)msg->value;
+	videoData->frm_no = video->frm_no;
+	videoData->ntp_timestamp = video->ntp_timestamp;
+	videoData->pts = video->pts;
+	videoData->type = video->type;
+	videoData->len = video->len;
+	memcpy(videoData->data, video->data, video->len);
+	int sz = msg_write((char *)msg, len);
+	free(msg);
+	if (sz != len) {
+		log_conn("stopped.");
+		gSspClient->stop();
+		gLoop->quit();
+	}
+}
+
+static void on_audio(imf::SspAudioData *audio)
+{
+	size_t len = sizeof(Message) + sizeof(AudioData) + audio->len;
+	auto *msg = (Message *)malloc(len);
+	msg->type = AudioDataMsg;
+	msg->length = sizeof(AudioData) + audio->len;
+	auto *audioData = (AudioData *)msg->value;
+	audioData->ntp_timestamp = audio->ntp_timestamp;
+	audioData->pts = audio->pts;
+	audioData->len = audio->len;
+	memcpy(audioData->data, audio->data, audio->len);
+
+	int sz = msg_write((char *)msg, len);
+	free(msg);
+	if (sz != len) {
+		log_conn("stopped.");
+		gSspClient->stop();
+		gLoop->quit();
+	}
+}
+static void on_meta(imf::SspVideoMeta *vmeta, struct imf::SspAudioMeta *ameta,
+		    struct imf::SspMeta *meta)
+{
+	size_t len = sizeof(Message) + sizeof(Metadata);
+	auto *msg = (Message *)malloc(len);
+	msg->type = MetaDataMsg;
+	msg->length = sizeof(Metadata);
+	auto *metadata = (Metadata *)msg->value;
+	metadata->ameta.bitrate = ameta->bitrate;
+	metadata->ameta.channel = ameta->channel;
+	metadata->ameta.encoder = ameta->encoder;
+	metadata->ameta.sample_rate = ameta->sample_rate;
+	metadata->ameta.sample_size = ameta->sample_size;
+	metadata->ameta.timescale = ameta->timescale;
+	metadata->ameta.unit = ameta->unit;
+
+	metadata->vmeta.encoder = vmeta->encoder;
+	metadata->vmeta.gop = vmeta->gop;
+	metadata->vmeta.height = vmeta->height;
+	metadata->vmeta.timescale = vmeta->timescale;
+	metadata->vmeta.unit = vmeta->unit;
+	metadata->vmeta.width = vmeta->width;
+
+	metadata->meta.pts_is_wall_clock = meta->pts_is_wall_clock;
+	metadata->meta.tc_drop_frame = meta->tc_drop_frame;
+	metadata->meta.timecode = meta->timecode;
+
+	int sz = msg_write((char *)msg, len);
+	free(msg);
+	if (sz != len) {
+		log_conn("stopped.");
+		gSspClient->stop();
+		gLoop->quit();
+	}
+}
+static void on_exception(int code, const char *description)
+{
+	size_t len =
+		sizeof(Message) + sizeof(Message) + strlen(description) + 1;
+	auto *msg = (Message *)malloc(len);
+	msg->type = ExceptionMsg;
+	msg->length = sizeof(Message) + strlen(description) + 1;
+	auto *errmsg = (Message *)msg->value;
+	errmsg->length = strlen(description) + 1;
+	errmsg->type = code;
+	strcpy((char *)errmsg->value, description);
+	int sz = msg_write((char *)msg, len);
+	free(msg);
+	if (sz != len) {
+		log_conn("stopped.");
+		gSspClient->stop();
+		gLoop->quit();
+	}
+}
+
+static void setup(imf::Loop *loop)
+{
+	auto client = new imf::SspClient(address, loop, 0x400000, port, 0);
+	client->init();
+	gSspClient = client;
+
+	client->setOnH264DataCallback(on_video);
+	client->setOnMetaCallback(on_meta);
+	client->setOnAudioDataCallback(on_audio);
+	client->setOnExceptionCallback(on_exception);
+	client->setOnConnectionConnectedCallback(
+		std::bind(on_general_message, ConnectionConnectedMsg));
+	client->setOnRecvBufferFullCallback(
+		std::bind(on_general_message, RecvBufferFullMsg));
+	client->setOnDisconnectedCallback(
+		std::bind(on_general_message, ExceptionMsg));
+	client->start();
+
+	Message msg;
+	msg.length = 0;
+	msg.type = ConnectorOkMsg;
+	int sz = msg_write((char *)&msg, sizeof(msg));
+
+	if (sz != sizeof(msg)) {
+		log_conn("stopped.");
+		client->stop();
+		gLoop->quit();
+	}
+}
+
+int main(int argc, char **argv)
+{
+	setbuf(stdout, nullptr); // unbuffered stdout
+	int ret = process_args(argc, argv);
+	if (ret) {
+		print_usage();
+		return -1;
+	}
+	log_conn("host: %s\nport: %d\nuuid: %s\n", address, port, uuid);
+	auto loop = new imf::Loop();
+	loop->init();
+	gLoop = loop;
+	setup(gLoop);
+	loop->loop();
+	log_conn("loop finished");
+	delete loop;
+	if (gSspClient) {
+		delete gSspClient;
+	}
+	return 0;
+}

--- a/ssp_connector/main.h
+++ b/ssp_connector/main.h
@@ -1,0 +1,30 @@
+/* 
+ * Copyright (c) 2015-2022, Yibai Zhang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 3.  Neither the name of Yibai Zhang, obs-ssp, ssp_connector
+ *     nor the names contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define log_conn(fmt, ...) \
+	fprintf(stderr, "%s:%d " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)

--- a/ssp_connector/ssp_connector_proto.h
+++ b/ssp_connector/ssp_connector_proto.h
@@ -1,0 +1,104 @@
+/* 
+ * Copyright (c) 2015-2021, Yibai Zhang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ * 3.  Neither the name of Yibai Zhang, obs-ssp, ssp_connector
+ *     nor the names contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SSP_CONNECTOR_PROTO_H_
+#define SSP_CONNECTOR_PROTO_H_
+
+#include <stdint.h>
+
+#pragma pack(1)
+
+#define SSP_PROTO
+
+struct SSP_PROTO VideoMeta {
+	uint32_t width;
+	uint32_t height;
+	uint32_t timescale;
+	uint32_t unit;
+	uint32_t gop;
+	uint32_t encoder;
+};
+
+struct SSP_PROTO AudioMeta {
+	uint32_t timescale;
+	uint32_t unit;
+	uint32_t sample_rate;
+	uint32_t sample_size;
+	uint32_t channel;
+	uint32_t bitrate;
+	uint32_t encoder;
+};
+
+struct SSP_PROTO BaseMeta {
+	uint16_t pts_is_wall_clock;
+	uint16_t tc_drop_frame;
+	uint32_t timecode;
+};
+
+struct SSP_PROTO Metadata {
+	struct BaseMeta meta;
+	struct VideoMeta vmeta;
+	struct AudioMeta ameta;
+};
+
+struct SSP_PROTO VideoData {
+	uint64_t pts;
+	uint64_t ntp_timestamp;
+	uint32_t frm_no;
+	uint32_t type; // I or P
+	size_t len;
+	uint8_t data[0];
+};
+
+struct SSP_PROTO AudioData {
+	uint64_t pts;
+	uint64_t ntp_timestamp;
+	size_t len;
+	uint8_t data[0];
+};
+
+enum MessageType {
+	MetaDataMsg = 1,
+	VideoDataMsg,
+	AudioDataMsg,
+	RecvBufferFullMsg,
+	DisconnectMsg,
+	ConnectionConnectedMsg,
+	ExceptionMsg,
+	ConnectorOkMsg,
+};
+
+struct Message {
+	uint32_t type;
+	uint32_t length;
+	uint8_t value[0];
+};
+
+#pragma pack()
+
+#endif


### PR DESCRIPTION
Since we can't find out why it always crash when libssp loaded on obs process, we isolate ssp protocol to a standalone process called ssp-connector and use stdout to communicate with obs.

And it happends that we can use the benefit of Rosetta2 to let obs on Apple Silicon support obs-ssp natively by only running ssp-connector process on Rosetta2. It's only a network thread so it's easy for Roestta2 to achieve its performance need.

Signed-off-by: Yibai Zhang <xm1994@gmail.com>