### PR TITLE
fix(ssp-client): Add os_process_pipe implementation from OBS

### DIFF
--- a/.github/actions/build-plugin/action.yaml
+++ b/.github/actions/build-plugin/action.yaml
@@ -33,6 +33,8 @@ runs:
       run: |
         : Run macOS Build
 
+        export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+
         local -a build_args=(--config ${{ inputs.config }})
         if (( ${+RUNNER_DEBUG} )) build_args+=(--debug)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,17 @@ set(obs-ssp_SOURCES
     src/ssp-mdns.cpp
     src/ssp-controller.cpp
     src/VFrameQueue.cpp
-    src/ssp-client-iso.cpp)
+    src/ssp-client-iso.cpp
+    src/util/pipe.c)
+
+if(OS_WINDOWS)
+  list(APPEND obs-ssp_SOURCES src/util/pipe-windows.c)
+else()
+  list(APPEND obs-ssp_SOURCES src/util/pipe-posix.c)
+endif()
 
 set(obs-ssp_HEADERS src/obs-ssp.h src/ssp-mdns.h src/ssp-controller.h src/VFrameQueue.h
-                    src/ssp-client.h)
+                    src/ssp-client.h src/util/pipe.h)
 
 target_sources(${CMAKE_PROJECT_NAME} PRIVATE ${obs-ssp_SOURCES})
 

--- a/src/ssp-client-iso.cpp
+++ b/src/ssp-client-iso.cpp
@@ -133,9 +133,6 @@ void SSPClientIso::doStart()
 	dstr_init_copy(&cmd, ssp_connector_path.toStdString().c_str());
 	dstr_insert_ch(&cmd, 0, '\"');
 	dstr_cat(&cmd, "\" ");
-#if defined(__APPLE__) && defined(__arm64__)
-	dstr_insert(&cmd, 0, "arch -x86_64 ");
-#endif
 	dstr_cat(&cmd, "--host ");
 	dstr_cat(&cmd, this->ip.c_str());
 	dstr_cat(&cmd, " --port ");

--- a/src/ssp-client-iso.h
+++ b/src/ssp-client-iso.h
@@ -25,7 +25,7 @@ along with this program; If not, see <https://www.gnu.org/licenses/>
 
 #include <imf/ISspClient.h>
 extern "C" {
-#include <util/pipe.h>
+#include "util/pipe.h"
 }
 #include <ssp_connector_proto.h>
 

--- a/src/util/c99defs.h
+++ b/src/util/c99defs.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Lain Bailey <lain@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+/*
+ * Contains hacks for getting some C99 stuff working in VC, things like
+ * bool, stdint
+ */
+
+#define UNUSED_PARAMETER(param) (void)param
+
+#ifdef _MSC_VER
+#define _OBS_DEPRECATED __declspec(deprecated)
+#define OBS_NORETURN __declspec(noreturn)
+#define FORCE_INLINE __forceinline
+#else
+#define _OBS_DEPRECATED __attribute__((deprecated))
+#define OBS_NORETURN __attribute__((noreturn))
+#define FORCE_INLINE inline __attribute__((always_inline))
+#endif
+
+#if defined(SWIG_TYPE_TABLE)
+#define OBS_DEPRECATED
+#else
+#define OBS_DEPRECATED _OBS_DEPRECATED
+#endif
+
+#if defined(IS_LIBOBS)
+#define OBS_EXTERNAL_DEPRECATED
+#else
+#define OBS_EXTERNAL_DEPRECATED OBS_DEPRECATED
+#endif
+
+#ifdef _MSC_VER
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT __attribute__((visibility("default")))
+#endif
+
+#ifdef _MSC_VER
+#define PRAGMA_WARN_PUSH _Pragma("warning(push)")
+#define PRAGMA_WARN_POP _Pragma("warning(pop)")
+#define PRAGMA_WARN_DEPRECATION _Pragma("warning(disable: 4996)")
+#elif defined(__clang__)
+#define PRAGMA_WARN_PUSH _Pragma("clang diagnostic push")
+#define PRAGMA_WARN_POP _Pragma("clang diagnostic pop")
+#define PRAGMA_WARN_DEPRECATION \
+	_Pragma("clang diagnostic warning \"-Wdeprecated-declarations\"")
+#elif defined(__GNUC__)
+#define PRAGMA_WARN_PUSH _Pragma("GCC diagnostic push")
+#define PRAGMA_WARN_POP _Pragma("GCC diagnostic pop")
+#define PRAGMA_WARN_DEPRECATION \
+	_Pragma("GCC diagnostic warning \"-Wdeprecated-declarations\"")
+#else
+#define PRAGMA_WARN_PUSH
+#define PRAGMA_WARN_POP
+#define PRAGMA_WARN_DEPRECATION
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>

--- a/src/util/pipe-posix.c
+++ b/src/util/pipe-posix.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2023 Lain Bailey <lain@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <errno.h>
+#include <spawn.h>
+#include <fcntl.h>
+
+#include <util/bmem.h>
+#include "pipe.h"
+
+extern char **environ;
+
+struct os_process_pipe {
+	bool read_pipe;
+	int pid;
+	FILE *file;
+	FILE *err_file;
+};
+
+os_process_pipe_t *os_process_pipe_create_internal(const char *bin, char **argv,
+						   const char *type)
+{
+	struct os_process_pipe process_pipe = {0};
+	struct os_process_pipe *out;
+	posix_spawn_file_actions_t file_actions;
+
+	if (!bin || !argv || !type) {
+		return NULL;
+	}
+
+	process_pipe.read_pipe = *type == 'r';
+
+	int mainfds[2] = {0};
+	int errfds[2] = {0};
+
+	if (pipe(mainfds) != 0) {
+		return NULL;
+	}
+
+	if (pipe(errfds) != 0) {
+		close(mainfds[0]);
+		close(mainfds[1]);
+
+		return NULL;
+	}
+
+	if (posix_spawn_file_actions_init(&file_actions) != 0) {
+		close(mainfds[0]);
+		close(mainfds[1]);
+		close(errfds[0]);
+		close(errfds[1]);
+
+		return NULL;
+	}
+
+	fcntl(mainfds[0], F_SETFD, FD_CLOEXEC);
+	fcntl(mainfds[1], F_SETFD, FD_CLOEXEC);
+	fcntl(errfds[0], F_SETFD, FD_CLOEXEC);
+	fcntl(errfds[1], F_SETFD, FD_CLOEXEC);
+
+	if (process_pipe.read_pipe) {
+		posix_spawn_file_actions_addclose(&file_actions, mainfds[0]);
+		if (mainfds[1] != STDOUT_FILENO) {
+			posix_spawn_file_actions_adddup2(
+				&file_actions, mainfds[1], STDOUT_FILENO);
+		}
+	} else {
+		posix_spawn_file_actions_addclose(&file_actions, mainfds[1]);
+		if (mainfds[0] != STDIN_FILENO) {
+			posix_spawn_file_actions_adddup2(
+				&file_actions, mainfds[0], STDIN_FILENO);
+		}
+	}
+
+	posix_spawn_file_actions_addclose(&file_actions, errfds[0]);
+	posix_spawn_file_actions_adddup2(&file_actions, errfds[1],
+					 STDERR_FILENO);
+
+	int pid;
+	int ret = posix_spawn(&pid, bin, &file_actions, NULL,
+			      (char *const *)argv, environ);
+
+	posix_spawn_file_actions_destroy(&file_actions);
+
+	if (ret != 0) {
+		close(mainfds[0]);
+		close(mainfds[1]);
+		close(errfds[0]);
+		close(errfds[1]);
+
+		return NULL;
+	}
+
+	close(errfds[1]);
+	process_pipe.err_file = fdopen(errfds[0], "r");
+
+	if (process_pipe.read_pipe) {
+		close(mainfds[1]);
+		process_pipe.file = fdopen(mainfds[0], "r");
+	} else {
+		close(mainfds[0]);
+		process_pipe.file = fdopen(mainfds[1], "w");
+	}
+
+	process_pipe.pid = pid;
+
+	out = bmalloc(sizeof(os_process_pipe_t));
+	*out = process_pipe;
+	return out;
+}
+
+os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
+					  const char *type)
+{
+	if (!cmd_line)
+		return NULL;
+
+	char *argv[4] = {"sh", "-c", (char *)cmd_line, NULL};
+	return os_process_pipe_create_internal("/bin/sh", argv, type);
+}
+
+os_process_pipe_t *os_process_pipe_create2(const os_process_args_t *args,
+					   const char *type)
+{
+	char **argv = os_process_args_get_argv(args);
+	return os_process_pipe_create_internal(argv[0], argv, type);
+}
+
+int os_process_pipe_destroy(os_process_pipe_t *pp)
+{
+	int ret = 0;
+
+	if (pp) {
+		int status;
+
+		fclose(pp->file);
+		pp->file = NULL;
+
+		fclose(pp->err_file);
+		pp->err_file = NULL;
+
+		do {
+			ret = waitpid(pp->pid, &status, 0);
+		} while (ret == -1 && errno == EINTR);
+
+		if (WIFEXITED(status))
+			ret = (int)(char)WEXITSTATUS(status);
+		bfree(pp);
+	}
+
+	return ret;
+}
+
+size_t os_process_pipe_read(os_process_pipe_t *pp, uint8_t *data, size_t len)
+{
+	if (!pp) {
+		return 0;
+	}
+	if (!pp->read_pipe) {
+		return 0;
+	}
+
+	return fread(data, 1, len, pp->file);
+}
+
+size_t os_process_pipe_read_err(os_process_pipe_t *pp, uint8_t *data,
+				size_t len)
+{
+	if (!pp) {
+		return 0;
+	}
+
+	return fread(data, 1, len, pp->err_file);
+}
+
+size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
+			     size_t len)
+{
+	if (!pp) {
+		return 0;
+	}
+	if (pp->read_pipe) {
+		return 0;
+	}
+
+	size_t written = 0;
+	while (written < len) {
+		size_t ret = fwrite(data + written, 1, len - written, pp->file);
+		if (!ret)
+			return written;
+
+		written += ret;
+	}
+	return written;
+}

--- a/src/util/pipe-windows.c
+++ b/src/util/pipe-windows.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2023 Lain Bailey <lain@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <util/platform.h>
+#include <util/bmem.h>
+#include <util/dstr.h>
+#include "pipe.h"
+
+struct os_process_pipe {
+	bool read_pipe;
+	HANDLE handle;
+	HANDLE handle_err;
+	HANDLE process;
+};
+
+static bool create_pipe(HANDLE *input, HANDLE *output)
+{
+	SECURITY_ATTRIBUTES sa = {0};
+
+	sa.nLength = sizeof(sa);
+	sa.bInheritHandle = true;
+
+	if (!CreatePipe(input, output, &sa, 0)) {
+		return false;
+	}
+
+	return true;
+}
+
+static inline bool create_process(const char *cmd_line, HANDLE stdin_handle,
+				  HANDLE stdout_handle, HANDLE stderr_handle,
+				  HANDLE *process)
+{
+	PROCESS_INFORMATION pi = {0};
+	wchar_t *cmd_line_w = NULL;
+	STARTUPINFOW si = {0};
+	bool success = false;
+
+	si.cb = sizeof(si);
+	si.dwFlags = STARTF_USESTDHANDLES | STARTF_FORCEOFFFEEDBACK;
+	si.hStdInput = stdin_handle;
+	si.hStdOutput = stdout_handle;
+	si.hStdError = stderr_handle;
+
+	DWORD flags = 0;
+#ifndef SHOW_SUBPROCESSES
+	flags = CREATE_NO_WINDOW;
+#endif
+
+	os_utf8_to_wcs_ptr(cmd_line, 0, &cmd_line_w);
+	if (cmd_line_w) {
+		success = !!CreateProcessW(NULL, cmd_line_w, NULL, NULL, true,
+					   flags, NULL, NULL, &si, &pi);
+
+		if (success) {
+			*process = pi.hProcess;
+			CloseHandle(pi.hThread);
+		} else {
+			// Not logging the full command line is intentional
+			// as it may contain stream keys etc.
+			blog(LOG_ERROR, "CreateProcessW failed: %lu",
+			     GetLastError());
+		}
+
+		bfree(cmd_line_w);
+	}
+
+	return success;
+}
+
+os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
+					  const char *type)
+{
+	os_process_pipe_t *pp = NULL;
+	bool read_pipe;
+	HANDLE process;
+	HANDLE output;
+	HANDLE err_input, err_output;
+	HANDLE input;
+	bool success;
+
+	if (!cmd_line || !type) {
+		return NULL;
+	}
+	if (*type != 'r' && *type != 'w') {
+		return NULL;
+	}
+	if (!create_pipe(&input, &output)) {
+		return NULL;
+	}
+
+	if (!create_pipe(&err_input, &err_output)) {
+		return NULL;
+	}
+
+	read_pipe = *type == 'r';
+
+	success = !!SetHandleInformation(read_pipe ? input : output,
+					 HANDLE_FLAG_INHERIT, false);
+	if (!success) {
+		goto error;
+	}
+
+	success = !!SetHandleInformation(err_input, HANDLE_FLAG_INHERIT, false);
+	if (!success) {
+		goto error;
+	}
+
+	success = create_process(cmd_line, read_pipe ? NULL : input,
+				 read_pipe ? output : NULL, err_output,
+				 &process);
+	if (!success) {
+		goto error;
+	}
+
+	pp = bmalloc(sizeof(*pp));
+
+	pp->handle = read_pipe ? input : output;
+	pp->read_pipe = read_pipe;
+	pp->process = process;
+	pp->handle_err = err_input;
+
+	CloseHandle(read_pipe ? output : input);
+	CloseHandle(err_output);
+	return pp;
+
+error:
+	CloseHandle(output);
+	CloseHandle(input);
+	return NULL;
+}
+
+static inline void add_backslashes(struct dstr *str, size_t count)
+{
+	while (count--)
+		dstr_cat_ch(str, '\\');
+}
+
+os_process_pipe_t *os_process_pipe_create2(const os_process_args_t *args,
+					   const char *type)
+{
+	struct dstr cmd_line = {0};
+
+	/* Convert list to command line as Windows does not have any API that
+	 * allows us to just pass argc/argv. */
+	char **argv = os_process_args_get_argv(args);
+
+	/* Based on Python subprocess module implementation. */
+	while (*argv) {
+		size_t bs_count = 0;
+		const char *arg = *argv;
+		bool needs_quotes = strlen(arg) == 0 ||
+				    strstr(arg, " ") != NULL ||
+				    strstr(arg, "\t") != NULL;
+
+		if (cmd_line.len)
+			dstr_cat_ch(&cmd_line, ' ');
+		if (needs_quotes)
+			dstr_cat_ch(&cmd_line, '"');
+
+		while (*arg) {
+			if (*arg == '\\') {
+				bs_count++;
+			} else if (*arg == '"') {
+				add_backslashes(&cmd_line, bs_count * 2);
+				dstr_cat(&cmd_line, "\\\"");
+				bs_count = 0;
+			} else {
+				if (bs_count) {
+					add_backslashes(&cmd_line, bs_count);
+					bs_count = 0;
+				}
+				dstr_cat_ch(&cmd_line, *arg);
+			}
+
+			arg++;
+		}
+
+		if (bs_count)
+			add_backslashes(&cmd_line, bs_count);
+
+		if (needs_quotes) {
+			add_backslashes(&cmd_line, bs_count);
+			dstr_cat_ch(&cmd_line, '"');
+		}
+
+		argv++;
+	}
+
+	os_process_pipe_t *ret = os_process_pipe_create(cmd_line.array, type);
+
+	dstr_free(&cmd_line);
+	return ret;
+}
+
+int os_process_pipe_destroy(os_process_pipe_t *pp)
+{
+	int ret = 0;
+
+	if (pp) {
+		DWORD code;
+
+		CloseHandle(pp->handle);
+		CloseHandle(pp->handle_err);
+
+		WaitForSingleObject(pp->process, INFINITE);
+		if (GetExitCodeProcess(pp->process, &code))
+			ret = (int)code;
+
+		CloseHandle(pp->process);
+		bfree(pp);
+	}
+
+	return ret;
+}
+
+size_t os_process_pipe_read(os_process_pipe_t *pp, uint8_t *data, size_t len)
+{
+	DWORD bytes_read;
+	bool success;
+
+	if (!pp) {
+		return 0;
+	}
+	if (!pp->read_pipe) {
+		return 0;
+	}
+
+	success = !!ReadFile(pp->handle, data, (DWORD)len, &bytes_read, NULL);
+	if (success && bytes_read) {
+		return bytes_read;
+	}
+
+	return 0;
+}
+
+size_t os_process_pipe_read_err(os_process_pipe_t *pp, uint8_t *data,
+				size_t len)
+{
+	DWORD bytes_read;
+	bool success;
+
+	if (!pp || !pp->handle_err) {
+		return 0;
+	}
+
+	success =
+		!!ReadFile(pp->handle_err, data, (DWORD)len, &bytes_read, NULL);
+	if (success && bytes_read) {
+		return bytes_read;
+	} else
+		bytes_read = GetLastError();
+
+	return 0;
+}
+
+size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
+			     size_t len)
+{
+	DWORD bytes_written;
+	bool success;
+
+	if (!pp) {
+		return 0;
+	}
+	if (pp->read_pipe) {
+		return 0;
+	}
+
+	success =
+		!!WriteFile(pp->handle, data, (DWORD)len, &bytes_written, NULL);
+	if (success && bytes_written) {
+		return bytes_written;
+	}
+
+	return 0;
+}

--- a/src/util/pipe.c
+++ b/src/util/pipe.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Dennis Sädtler <dennis@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "pipe.h"
+#include <util/darray.h>
+#include <util/dstr.h>
+
+struct os_process_args {
+	DARRAY(char *) arguments;
+};
+
+struct os_process_args *os_process_args_create(const char *executable)
+{
+	struct os_process_args *args = bzalloc(sizeof(struct os_process_args));
+	char *str = bstrdup(executable);
+	da_push_back(args->arguments, &str);
+	/* Last item in argv must be NULL. */
+	char *terminator = NULL;
+	da_push_back(args->arguments, &terminator);
+	return args;
+}
+
+void os_process_args_add_arg(struct os_process_args *args, const char *arg)
+{
+	char *str = bstrdup(arg);
+	/* Insert before NULL list terminator. */
+	da_insert(args->arguments, args->arguments.num - 1, &str);
+}
+
+void os_process_args_add_argf(struct os_process_args *args, const char *format,
+			      ...)
+{
+	va_list va_args;
+	struct dstr tmp = {0};
+
+	va_start(va_args, format);
+	dstr_vprintf(&tmp, format, va_args);
+	da_insert(args->arguments, args->arguments.num - 1, &tmp.array);
+	va_end(va_args);
+}
+
+size_t os_process_args_get_argc(struct os_process_args *args)
+{
+	/* Do not count terminating NULL. */
+	return args->arguments.num - 1;
+}
+
+char **os_process_args_get_argv(const struct os_process_args *args)
+{
+	return args->arguments.array;
+}
+
+void os_process_args_destroy(struct os_process_args *args)
+{
+	if (!args)
+		return;
+
+	for (size_t idx = 0; idx < args->arguments.num; idx++)
+		bfree(args->arguments.array[idx]);
+
+	da_free(args->arguments);
+	bfree(args);
+}

--- a/src/util/pipe.h
+++ b/src/util/pipe.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Lain Bailey <lain@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include "c99defs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct os_process_pipe;
+typedef struct os_process_pipe os_process_pipe_t;
+
+struct os_process_args;
+typedef struct os_process_args os_process_args_t;
+
+EXPORT os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
+						 const char *type);
+EXPORT os_process_pipe_t *os_process_pipe_create2(const os_process_args_t *args,
+						  const char *type);
+EXPORT int os_process_pipe_destroy(os_process_pipe_t *pp);
+
+EXPORT size_t os_process_pipe_read(os_process_pipe_t *pp, uint8_t *data,
+				   size_t len);
+EXPORT size_t os_process_pipe_read_err(os_process_pipe_t *pp, uint8_t *data,
+				       size_t len);
+EXPORT size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
+				    size_t len);
+
+EXPORT struct os_process_args *os_process_args_create(const char *executable);
+EXPORT void os_process_args_add_arg(struct os_process_args *args,
+				    const char *arg);
+#ifndef _MSC_VER
+__attribute__((__format__(__printf__, 2, 3)))
+#endif
+EXPORT void
+os_process_args_add_argf(struct os_process_args *args, const char *format, ...);
+EXPORT char **os_process_args_get_argv(const struct os_process_args *args);
+EXPORT size_t os_process_args_get_argc(struct os_process_args *args);
+EXPORT void os_process_args_destroy(struct os_process_args *args);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ssp_connector/CMakeLists.txt
+++ b/ssp_connector/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   libssp
   GIT_REPOSITORY "https://github.com/imaginevision/libssp.git"
-  GIT_TAG ee754be1d2ed54633ff467a7cd6fec14c9b0b537)
+  GIT_TAG f9882aeebdda781d14262fcc04b9038a567ac985)
 
 if(NOT libssp_POPULATED)
   FetchContent_Populate(libssp)
@@ -17,16 +17,21 @@ if(NOT libssp_POPULATED)
         "${libssp_SOURCE_DIR}/lib/win_x64_vs2017/libssp$<$<CONFIG:Debug>:d>.dll"
         PARENT_SCOPE)
   elseif(OS_MACOS)
-    target_link_libraries(libssp INTERFACE ${libssp_SOURCE_DIR}/lib/mac/libssp.dylib)
-    set(LIBSSP_LIBRARY
-        "${libssp_SOURCE_DIR}/lib/mac/libssp.dylib"
-        PARENT_SCOPE)
+    set(_COMMAND
+        "lipo -create \"${libssp_SOURCE_DIR}/lib/mac_arm64/libssp.dylib\" \
+        \"${libssp_SOURCE_DIR}/lib/mac/libssp.dylib\" \
+        -output \"${CMAKE_CURRENT_BINARY_DIR}/libssp.dylib\"")
+    message(STATUS ${_COMMAND})
+    execute_process(COMMAND /bin/sh -c "${_COMMAND}")
+    set(LIBSSP_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/libssp.dylib")
+    set(LIBSSP_LIBRARY "${LIBSSP_LIBRARY}" PARENT_SCOPE)
+    target_link_libraries(libssp INTERFACE "${LIBSSP_LIBRARY}")
     set(_COMMAND
         "/usr/bin/codesign --force \\
         --sign \"${CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY}\" \
         --options runtime \
         --entitlements \"${CMAKE_CURRENT_LIST_DIR}/../cmake/bundle/macOS/entitlements.plist\" \
-        \"${libssp_SOURCE_DIR}/lib/mac/libssp.dylib\"")
+        \"${LIBSSP_LIBRARY}\"")
     execute_process(COMMAND /bin/sh -c "${_COMMAND}")
   endif()
 endif()
@@ -34,7 +39,6 @@ endif()
 set(SSP_CONNECTOR_SOURCE main.cpp)
 
 add_executable(ssp-connector ${SSP_CONNECTOR_SOURCE})
-set_target_properties(ssp-connector PROPERTIES OSX_ARCHITECTURES x86_64)
 target_link_libraries(ssp-connector PRIVATE libssp)
 target_include_directories(ssp-connector PRIVATE libuv/include)
 


### PR DESCRIPTION
Since upstream produced a bug and repair too slowly, we move codes to our own repository and fix that.

Also update libssp to latest version and no need to use rosetta2.